### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,4 @@
 approvers:
 - dionysbot
-- ram4444
 reviewers:
 - dionysbot
-- ram4444

--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,6 @@
 approvers:
 - dionysbot
+- ram4444
 reviewers:
 - dionysbot
+- ram4444

--- a/bdd/bdd.sh
+++ b/bdd/bdd.sh
@@ -9,9 +9,9 @@ fi
 SRC_PATH=$1
 DST_PATH=$2
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_EMAIL="jenkins-x@googlegroups.com"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="dionysbot"
+export GH_EMAIL="dionysbiz@gmail.com"
+export GH_OWNER="dionysbiz"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/bdd/boot-local/parameters.yaml
+++ b/bdd/boot-local/parameters.yaml
@@ -6,5 +6,5 @@ gpg: {}
 pipelineUser:
   github:
     host: github.com
-    username: jenkins-x-bot-test
-    email: jenkins-x@googlegroups.com
+    username: dionysbot
+    email: dionysbiz@gmail.com

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testapprove7](https://github.com/dionysbiz/testapprove7.git) |  | []() | 
+[dionysbiz/testapprove8](https://github.com/dionysbiz/testapprove8.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testorgbiz](https://github.com/dionysbiz/testorgbiz.git) |  | []() | 
+[dionysbiz/testorg2](https://github.com/dionysbiz/testorg2.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[dionysbiz/testorgbiz](https://github.com/dionysbiz/testorgbiz.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testorg3](https://github.com/dionysbiz/testorg3.git) |  | []() | 
+[dionysbiz/testorg4](https://github.com/dionysbiz/testorg4.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testorg4](https://github.com/dionysbiz/testorg4.git) |  | []() | 
+[dionysbiz/testorg5](https://github.com/dionysbiz/testorg5.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testretest](https://github.com/dionysbiz/testretest.git) |  | []() | 
+[dionysbiz/testretest2](https://github.com/dionysbiz/testretest2.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/reactq](https://github.com/dionysbiz/reactq.git) |  | []() | 
+[dionysbiz/testretest](https://github.com/dionysbiz/testretest.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testorg2](https://github.com/dionysbiz/testorg2.git) |  | []() | 
+[dionysbiz/testorg3](https://github.com/dionysbiz/testorg3.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testownerasram](https://github.com/dionysbiz/testownerasram.git) |  | []() | 
+[dionysbiz/testownerasram4](https://github.com/dionysbiz/testownerasram4.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testaddowner](https://github.com/dionysbiz/testaddowner.git) |  | []() | 
+[dionysbiz/testownerasram](https://github.com/dionysbiz/testownerasram.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testorg5](https://github.com/dionysbiz/testorg5.git) |  | []() | 
+[dionysbiz/testlighthouse](https://github.com/dionysbiz/testlighthouse.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testlighthouse](https://github.com/dionysbiz/testlighthouse.git) |  | []() | 
+[dionysbiz/testaddowner](https://github.com/dionysbiz/testaddowner.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testnode](https://github.com/dionysbiz/testnode.git) |  | []() | 
+[dionysbiz/reactq](https://github.com/dionysbiz/reactq.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testapprove8](https://github.com/dionysbiz/testapprove8.git) |  | []() | 
+[dionysbiz/testnode](https://github.com/dionysbiz/testnode.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[dionysbiz/testownerasram4](https://github.com/dionysbiz/testownerasram4.git) |  | []() | 
+[dionysbiz/testapprove7](https://github.com/dionysbiz/testapprove7.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testlighthouse
-  url: https://github.com/dionysbiz/testlighthouse.git
+  repo: testaddowner
+  url: https://github.com/dionysbiz/testaddowner.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testaddowner
-  url: https://github.com/dionysbiz/testaddowner.git
+  repo: testownerasram
+  url: https://github.com/dionysbiz/testownerasram.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testretest
-  url: https://github.com/dionysbiz/testretest.git
+  repo: testretest2
+  url: https://github.com/dionysbiz/testretest2.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testapprove7
-  url: https://github.com/dionysbiz/testapprove7.git
+  repo: testapprove8
+  url: https://github.com/dionysbiz/testapprove8.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testorg5
-  url: https://github.com/dionysbiz/testorg5.git
+  repo: testlighthouse
+  url: https://github.com/dionysbiz/testlighthouse.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testownerasram4
-  url: https://github.com/dionysbiz/testownerasram4.git
+  repo: testapprove7
+  url: https://github.com/dionysbiz/testapprove7.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: reactq
-  url: https://github.com/dionysbiz/reactq.git
+  repo: testretest
+  url: https://github.com/dionysbiz/testretest.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testapprove8
-  url: https://github.com/dionysbiz/testapprove8.git
+  repo: testnode
+  url: https://github.com/dionysbiz/testnode.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testorg2
-  url: https://github.com/dionysbiz/testorg2.git
+  repo: testorg3
+  url: https://github.com/dionysbiz/testorg3.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testorg4
-  url: https://github.com/dionysbiz/testorg4.git
+  repo: testorg5
+  url: https://github.com/dionysbiz/testorg5.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testnode
-  url: https://github.com/dionysbiz/testnode.git
+  repo: reactq
+  url: https://github.com/dionysbiz/reactq.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: dionysbiz
+  repo: testorgbiz
+  url: https://github.com/dionysbiz/testorgbiz.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testorg3
-  url: https://github.com/dionysbiz/testorg3.git
+  repo: testorg4
+  url: https://github.com/dionysbiz/testorg4.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testorgbiz
-  url: https://github.com/dionysbiz/testorgbiz.git
+  repo: testorg2
+  url: https://github.com/dionysbiz/testorg2.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: dionysbiz
-  repo: testownerasram
-  url: https://github.com/dionysbiz/testownerasram.git
+  repo: testownerasram4
+  url: https://github.com/dionysbiz/testownerasram4.git
   version: ""
   versionURL: ""

--- a/env/parameters.yaml
+++ b/env/parameters.yaml
@@ -2,10 +2,10 @@ adminUser:
   password: local:jx/adminUser:password
   username: ram4444
 docker:
-  email: ramwt4444@gmail.com
+  email: dionysbiz@gmail.com
   password: local:jx/docker:password
   url: https://index.docker.io/v1/
-  username: ram4444
+  username: dionysbiz
 enableDocker: true
 pipelineUser:
   email: dionysbiz@gmail.com

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -81,4 +81,4 @@ velero:
 versionStream:
   ref: v1.0.555
   url: https://github.com/jenkins-x/jenkins-x-versions
-webhook: prow
+webhook: lighthouse

--- a/repositories/templates/dionysbiz-reactq-sr.yaml
+++ b/repositories/templates/dionysbiz-reactq-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: reactq
+  name: dionysbiz-reactq
+spec:
+  description: Imported application for dionysbiz/reactq
+  httpCloneURL: https://github.com/dionysbiz/reactq.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: reactq
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/reactq.git

--- a/repositories/templates/dionysbiz-testaddowner-sr.yaml
+++ b/repositories/templates/dionysbiz-testaddowner-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testaddowner
+  name: dionysbiz-testaddowner
+spec:
+  description: Imported application for dionysbiz/testaddowner
+  httpCloneURL: https://github.com/dionysbiz/testaddowner.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testaddowner
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testaddowner.git

--- a/repositories/templates/dionysbiz-testapprove7-sr.yaml
+++ b/repositories/templates/dionysbiz-testapprove7-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testapprove7
+  name: dionysbiz-testapprove7
+spec:
+  description: Imported application for dionysbiz/testapprove7
+  httpCloneURL: https://github.com/dionysbiz/testapprove7.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testapprove7
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testapprove7.git

--- a/repositories/templates/dionysbiz-testapprove8-sr.yaml
+++ b/repositories/templates/dionysbiz-testapprove8-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testapprove8
+  name: dionysbiz-testapprove8
+spec:
+  description: Imported application for dionysbiz/testapprove8
+  httpCloneURL: https://github.com/dionysbiz/testapprove8.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testapprove8
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testapprove8.git

--- a/repositories/templates/dionysbiz-testlighthouse-sr.yaml
+++ b/repositories/templates/dionysbiz-testlighthouse-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testlighthouse
+  name: dionysbiz-testlighthouse
+spec:
+  description: Imported application for dionysbiz/testlighthouse
+  httpCloneURL: https://github.com/dionysbiz/testlighthouse.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testlighthouse
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testlighthouse.git

--- a/repositories/templates/dionysbiz-testnode-sr.yaml
+++ b/repositories/templates/dionysbiz-testnode-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testnode
+  name: dionysbiz-testnode
+spec:
+  description: Imported application for dionysbiz/testnode
+  httpCloneURL: https://github.com/dionysbiz/testnode.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testnode
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testnode.git

--- a/repositories/templates/dionysbiz-testorg2-sr.yaml
+++ b/repositories/templates/dionysbiz-testorg2-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testorg2
+  name: dionysbiz-testorg2
+spec:
+  description: Imported application for dionysbiz/testorg2
+  httpCloneURL: https://github.com/dionysbiz/testorg2.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testorg2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testorg2.git

--- a/repositories/templates/dionysbiz-testorg3-sr.yaml
+++ b/repositories/templates/dionysbiz-testorg3-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testorg3
+  name: dionysbiz-testorg3
+spec:
+  description: Imported application for dionysbiz/testorg3
+  httpCloneURL: https://github.com/dionysbiz/testorg3.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testorg3
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testorg3.git

--- a/repositories/templates/dionysbiz-testorg4-sr.yaml
+++ b/repositories/templates/dionysbiz-testorg4-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testorg4
+  name: dionysbiz-testorg4
+spec:
+  description: Imported application for dionysbiz/testorg4
+  httpCloneURL: https://github.com/dionysbiz/testorg4.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testorg4
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testorg4.git

--- a/repositories/templates/dionysbiz-testorg5-sr.yaml
+++ b/repositories/templates/dionysbiz-testorg5-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testorg5
+  name: dionysbiz-testorg5
+spec:
+  description: Imported application for dionysbiz/testorg5
+  httpCloneURL: https://github.com/dionysbiz/testorg5.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testorg5
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testorg5.git

--- a/repositories/templates/dionysbiz-testorgbiz-sr.yaml
+++ b/repositories/templates/dionysbiz-testorgbiz-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testorgbiz
+  name: dionysbiz-testorgbiz
+spec:
+  description: Imported application for dionysbiz/testorgbiz
+  httpCloneURL: https://github.com/dionysbiz/testorgbiz.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testorgbiz
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testorgbiz.git

--- a/repositories/templates/dionysbiz-testownerasram-sr.yaml
+++ b/repositories/templates/dionysbiz-testownerasram-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testownerasram
+  name: dionysbiz-testownerasram
+spec:
+  description: Imported application for dionysbiz/testownerasram
+  httpCloneURL: https://github.com/dionysbiz/testownerasram.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testownerasram
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testownerasram.git

--- a/repositories/templates/dionysbiz-testownerasram4-sr.yaml
+++ b/repositories/templates/dionysbiz-testownerasram4-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testownerasram4
+  name: dionysbiz-testownerasram4
+spec:
+  description: Imported application for dionysbiz/testownerasram4
+  httpCloneURL: https://github.com/dionysbiz/testownerasram4.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testownerasram4
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testownerasram4.git

--- a/repositories/templates/dionysbiz-testretest-sr.yaml
+++ b/repositories/templates/dionysbiz-testretest-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testretest
+  name: dionysbiz-testretest
+spec:
+  description: Imported application for dionysbiz/testretest
+  httpCloneURL: https://github.com/dionysbiz/testretest.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testretest
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testretest.git

--- a/repositories/templates/dionysbiz-testretest2-sr.yaml
+++ b/repositories/templates/dionysbiz-testretest2-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: dionysbiz
+    provider: github
+    repository: testretest2
+  name: dionysbiz-testretest2
+spec:
+  description: Imported application for dionysbiz/testretest2
+  httpCloneURL: https://github.com/dionysbiz/testretest2.git
+  org: dionysbiz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: testretest2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/dionysbiz/testretest2.git


### PR DESCRIPTION
Update [dionysbiz/testretest2](https://github.com/dionysbiz/testretest2.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testretest](https://github.com/dionysbiz/testretest.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/reactq](https://github.com/dionysbiz/reactq.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testnode](https://github.com/dionysbiz/testnode.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testapprove8](https://github.com/dionysbiz/testapprove8.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testapprove7](https://github.com/dionysbiz/testapprove7.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testownerasram4](https://github.com/dionysbiz/testownerasram4.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testownerasram](https://github.com/dionysbiz/testownerasram.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testaddowner](https://github.com/dionysbiz/testaddowner.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testlighthouse](https://github.com/dionysbiz/testlighthouse.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testorg5](https://github.com/dionysbiz/testorg5.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testorg4](https://github.com/dionysbiz/testorg4.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testorg3](https://github.com/dionysbiz/testorg3.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testorg2](https://github.com/dionysbiz/testorg2.git) 

Command run was `jx create quickstart`
<hr />

Update [dionysbiz/testorgbiz](https://github.com/dionysbiz/testorgbiz.git) 

Command run was `jx create quickstart`